### PR TITLE
Got rid of comment which renders in webpage

### DIFF
--- a/login_buttons_dialogs.html
+++ b/login_buttons_dialogs.html
@@ -3,8 +3,6 @@
   {{> _enrollAccountDialog}}
   {{> _justVerifiedEmailDialog}}
   {{> _configureLoginServiceDialog}}
-
-  <!-- if we're not showing a dropdown, we need some other place to show messages -->
   {{> _loginButtonsMessagesDialog}}
 </body>
 


### PR DESCRIPTION
The comment `<!-- if we're not showing a dropdown, we need some other place to show messages -->` always renders in web pages, and looks weird in the site source. It'd be nice if this could be removed.
